### PR TITLE
Minor fixes

### DIFF
--- a/api/youtube-api.js
+++ b/api/youtube-api.js
@@ -135,7 +135,10 @@ function storeToken(token) {
         }
     }
 
-  fs.writeFile(TOKEN_PATH, JSON.stringify(token));
+  fs.writeFile(TOKEN_PATH, JSON.stringify(token), (err) => {
+    if (err)
+      console.log(err);
+    });
   winston.info('Token stored to ' + TOKEN_PATH, { source: 'youtube' });
 }
 

--- a/config.template.json
+++ b/config.template.json
@@ -3,7 +3,8 @@
     "port": 4242,
     "whitelisted_ips": [
         "127.0.0.1",
-        "::1"
+        "::1",
+        "::ffff:127.0.0.1"
     ],
     "live_data": {
         "youtube": {


### PR DESCRIPTION
Some minor fixes
The first commit fixes the `TypeError [ERR_INVALID_ARG_TYPE]: The "cb" argument must be of type function. Received undefined` error when trying to authenticate to use the Youtube chat.
The second one is a sometimes small addition to the whitelisted_ips due to some setups seeming to prefer ipv6 despite only having an ipv4 address afaict.

Do note I've only setup Twitch and Youtube, so other errors (such as the security warnings given by npm) are not fixed by this PR